### PR TITLE
typo + media query overlap fix

### DIFF
--- a/ucsf-starterkit-images-responsive.css
+++ b/ucsf-starterkit-images-responsive.css
@@ -190,10 +190,10 @@
   .file-entity-square-sixth,
   .media-square-sixth,
   .media-sixth {
-    width: 0.16666666666666%;
+    width: 16.66666666666666%;
   }
 }
-@media screen and (max-width: 380px) {
+@media screen and (max-width: 379px) {
   /* line 135, ucsf-starterkit-images-responsive.scss */
   .file-entity-half,
   .file-entity-square-half,
@@ -320,7 +320,7 @@
   .two-sidebars .sidebar-second .file-entity-square-sixth,
   .two-sidebars .sidebar-second .media-square-sixth,
   .two-sidebars .sidebar-second .media-sixth {
-    width: 0.16666666666666%;
+    width: 16.66666666666666%;
   }
 }
 /* line 221, ucsf-starterkit-images-responsive.scss */

--- a/ucsf-starterkit-images-responsive.css
+++ b/ucsf-starterkit-images-responsive.css
@@ -160,7 +160,7 @@
     width: 25%;
   }
 }
-@media screen and (min-width: 380px) and (max-width: 819px) {
+@media screen and (min-width: 376px) and (max-width: 819px) {
   /* line 115, ucsf-starterkit-images-responsive.scss */
   .file-entity-half,
   .file-entity-square-half,
@@ -193,7 +193,7 @@
     width: 16.66666666666666%;
   }
 }
-@media screen and (max-width: 379px) {
+@media screen and (max-width: 375px) {
   /* line 135, ucsf-starterkit-images-responsive.scss */
   .file-entity-half,
   .file-entity-square-half,

--- a/ucsf-starterkit-images-responsive.css
+++ b/ucsf-starterkit-images-responsive.css
@@ -160,7 +160,7 @@
     width: 25%;
   }
 }
-@media screen and (min-width: 376px) and (max-width: 819px) {
+@media screen and (min-width: 380px) and (max-width: 819px) {
   /* line 115, ucsf-starterkit-images-responsive.scss */
   .file-entity-half,
   .file-entity-square-half,
@@ -193,7 +193,7 @@
     width: 16.66666666666666%;
   }
 }
-@media screen and (max-width: 375px) {
+@media screen and (max-width: 379px) {
   /* line 135, ucsf-starterkit-images-responsive.scss */
   .file-entity-half,
   .file-entity-square-half,

--- a/ucsf-starterkit-images-responsive.scss
+++ b/ucsf-starterkit-images-responsive.scss
@@ -11,6 +11,9 @@ $display_medium_min: 630px;
 $display_small_max: 629px;
 $display_small_min: 380px;
 
+// older mobile portrait
+$display_mobile_max: 379px;
+
 @media screen and (min-width: $display_medium_min) {
 	/**
 	 * 1/4
@@ -124,11 +127,11 @@ $display_small_min: 380px;
 	.file-entity-sixth,
 	.file-entity-square-sixth,
 	.media-square-sixth,
-	.media-sixth { width: 0.16666666666666%;}
+	.media-sixth { width: 16.66666666666666%;}
 }
 
 // This is the mobile
-@media screen and (max-width: $display_small_min) {
+@media screen and (max-width: $display_mobile_max) {
 	.file-entity-half,
 	.file-entity-square-half,
 	.media-square-half,
@@ -214,7 +217,7 @@ $display_small_min: 380px;
 		.file-entity-sixth,
 		.file-entity-square-sixth,
 		.media-square-sixth,
-		.media-sixth { width: 0.16666666666666%;}
+		.media-sixth { width: 16.66666666666666%;}
 	}
 }
 

--- a/ucsf-starterkit-images-responsive.scss
+++ b/ucsf-starterkit-images-responsive.scss
@@ -9,10 +9,10 @@ $display_medium_min: 630px;
 
 // Handheld and small display screen
 $display_small_max: 629px;
-$display_small_min: 380px;
+$display_small_min: 376px;
 
 // older mobile portrait
-$display_mobile_max: 379px;
+$display_mobile_max: 375px;
 
 @media screen and (min-width: $display_medium_min) {
 	/**

--- a/ucsf-starterkit-images-responsive.scss
+++ b/ucsf-starterkit-images-responsive.scss
@@ -9,10 +9,10 @@ $display_medium_min: 630px;
 
 // Handheld and small display screen
 $display_small_max: 629px;
-$display_small_min: 376px;
+$display_small_min: 380px;
 
 // older mobile portrait
-$display_mobile_max: 375px;
+$display_mobile_max: 379px;
 
 @media screen and (min-width: $display_medium_min) {
 	/**


### PR DESCRIPTION
Wrong decimal point for smaller sixth images, that was a simple fix.

I also created a new breakpoint - not a huge deal but before you'd have two different media queries competing at 380px.
